### PR TITLE
Restore old upload folder 

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -124,6 +124,8 @@ services:
     environment:
       LEGACY_APP_COOKIE_DOMAIN: ${BEABEE_COOKIE_DOMAIN}
       TRUSTED_ORIGINS: ${BEABEE_TRUSTEDORIGINS-}
+    volumes:
+      - upload_data:/old_data
     depends_on:
       - api_app
       - app
@@ -160,5 +162,6 @@ networks:
     external: true
 
 volumes:
+  upload_data:
   minio_data:
   telegram-bot_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,8 @@ services:
     environment:
       LEGACY_APP_COOKIE_DOMAIN: ${BEABEE_COOKIE_DOMAIN}
       TRUSTED_ORIGINS: ${BEABEE_TRUSTEDORIGINS-}
+    volumes:
+      - upload_data:/old_data
     depends_on:
       - api_app
       - app
@@ -160,5 +162,6 @@ networks:
     external: true
 
 volumes:
+  upload_data:
   minio_data:
   telegram-bot_data:


### PR DESCRIPTION
Although we wanted to remove the migration service, we shouldn't have removed the old folder as that could break old URLs