### PR TITLE
feat: migrate to remote MinIO instance

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -12,6 +12,7 @@ x-base-app: &base-app
   networks:
     - internal
     - db-network
+    - storage-network
   logging: &logging
     driver: gelf
     options:

--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -75,6 +75,7 @@ services:
       <<: *logging
     networks:
       - internal
+      - storage-network
 
   # Migration service
   migration:
@@ -157,6 +158,8 @@ networks:
   internal:
     driver: bridge
   db-network:
+    external: true
+  storage-network:
     external: true
   traefik-ingress:
     external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-base-app: &base-app
   networks:
     - internal
     - db-network
+    - storage-network
   logging: &logging
     driver: gelf
     options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       <<: *logging
     networks:
       - internal
+      - storage-network
 
   # Migration service
   migration:
@@ -157,6 +158,8 @@ networks:
   internal:
     driver: bridge
   db-network:
+    external: true
+  storage-network:
     external: true
   traefik-ingress:
     external: true

--- a/migrate-minio.sh
+++ b/migrate-minio.sh
@@ -1,0 +1,45 @@
+minio_bucket=beabee-$1
+minio_user=$minio_bucket
+minio_password=$(pwgen -y 24)
+
+cat <<EOF
+
+mc alias set local http://localhost:9000 \$MINIO_ROOT_USER \$MINIO_ROOT_PASSWORD
+mc mb local/$minio_bucket
+
+cat > policy.json <<EOP
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:ListBucket"],
+      "Resource": ["arn:aws:s3:::$minio_bucket"]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:PutObject",
+        "s3:DeleteObject",
+        "s3:AbortMultipartUpload",
+        "s3:ListMultipartUploadParts",
+        "s3:ListBucketMultipartUploads"
+      ],
+      "Resource": ["arn:aws:s3:::$minio_bucket/*"]
+    }
+  ]
+}
+EOP
+mc admin policy create local $minio_bucket-rw policy.json
+
+mc admin user add local $minio_user "$minio_password"
+mc admin policy attach local $minio_bucket-rw --user $minio_user
+
+####################
+
+mc alias set local http://localhost:9000 \$MINIO_ROOT_USER \$MINIO_ROOT_PASSWORD
+mc alias set remote http://minio-minio-1:9000 $minio_user "$minio_password"
+
+mc mirror local/uploads remote/$minio_bucket
+EOF

--- a/migrate-minio.sh
+++ b/migrate-minio.sh
@@ -41,5 +41,13 @@ mc admin policy attach local $minio_bucket-rw --user $minio_user
 mc alias set local http://localhost:9000 \$MINIO_ROOT_USER \$MINIO_ROOT_PASSWORD
 mc alias set remote http://minio-minio-1:9000 $minio_user "$minio_password"
 
-mc mirror local/uploads remote/$minio_bucket
+mc mirror -a local/uploads remote/$minio_bucket
+
+####################
+
+
+BEABEE_MINIO_ENDPOINT=http://minio-minio-1:9000
+BEABEE_MINIO_BUCKET=$minio_bucket
+BEABEE_MINIO_ROOT_USER=$minio_user
+BEABEE_MINIO_ROOT_PASSWORD=$minio_password
 EOF


### PR DESCRIPTION
This PR connects a client's local MinIO instance to the remote one via the `storage-network`, so the data can be mirrored across. It includes a temporary script to generate the commands to be run on the remote and locale MinIO servers.

The migration process is as follows:
1. Create new bucket in remote MinIO instance
2. Switch instance to this branch in Portainer
3. Transfer data from local to remote MinIO instance
4. Set `BEABEE_MINIO_*` environment variables and redeploy
5. Switch instance to `feat/external-minio` branch and clean up old volumes/containers