### PR TITLE
Remove /old_data mount, data has been migrated to S3 bucket

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -124,8 +124,6 @@ services:
       HIVE_SERVICE_FRONTEND: ${HIVE_SERVICE_FRONTEND-}
       HIVE_SERVICE_FRONTEND_NEW: ${HIVE_SERVICE_FRONTEND_NEW-}
       HIVE_SERVICE_TELEGRAM_BOT: ${HIVE_SERVICE_TELEGRAM_BOT-}
-    volumes:
-      - upload_data:/old_data
     depends_on:
       - api_app
       - app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,8 +124,6 @@ services:
       HIVE_SERVICE_FRONTEND: ${HIVE_SERVICE_FRONTEND-}
       HIVE_SERVICE_FRONTEND_NEW: ${HIVE_SERVICE_FRONTEND_NEW-}
       HIVE_SERVICE_TELEGRAM_BOT: ${HIVE_SERVICE_TELEGRAM_BOT-}
-    volumes:
-      - upload_data:/old_data
     depends_on:
       - api_app
       - app


### PR DESCRIPTION
Remove the old data volume restored in #12 as we have now migrated all legacy images to the new S3-compatible storage